### PR TITLE
Additional info in +page.md

### DIFF
--- a/src/routes/docs/macos/+page.md
+++ b/src/routes/docs/macos/+page.md
@@ -16,9 +16,9 @@ title: Install on MacOS
 !!!
 !!!step title="Open"|description='Go to "Applications", right-click on the FreeShow app, and click "Open"'
 !!!
-!!!step title="Prompt"|description='Click "Cancel"'
+!!!step title="Prompt"|description='Click "Cancel", instead of "Move to Trash"'
 !!!
-!!!step title="Privacy&Security"|description='Go to "System Preferences" -> Security & Privacy -> Scroll down and click "Open anyway" next to "FreeShow was blocked[...]"'
+!!!step title="Open"|description='Again, go to "Applications", right-click on the FreeShow app, and click "Open"'
 !!!
 !!!step title="Prompt"|description='Click "Open"'
 !!!

--- a/src/routes/docs/macos/+page.md
+++ b/src/routes/docs/macos/+page.md
@@ -12,6 +12,14 @@ title: Install on MacOS
 
 !!!step title="Open"|description='Right-click on the .dmg file, and click "Open"'
 !!!
+!!!step title="Copy"|description='Drag "FreeShow" icon into "Applications" folder'
+!!!
+!!!step title="Open"|description='Go to "Applications", right-click on the FreeShow app, and click "Open"'
+!!!
+!!!step title="Prompt"|description='Click "Cancel"'
+!!!
+!!!step title="Privacy&Security"|description='Go to "System Preferences" -> Security & Privacy -> Scroll down and click "Open anyway" next to "FreeShow was blocked[...]"'
+!!!
 !!!step title="Prompt"|description='Click "Open"'
 !!!
 
@@ -20,5 +28,8 @@ title: Install on MacOS
 :::admonition type=info
 
 Note that I have not purchased any code signing keys yet _($129/year)_, so you will be prompted with a warning when installing as for now.
+
+After launch, you will be asked for permission to allow incoming network connections. If you deny, then RemoteShow, StageShow and ControlShow won't work.
+
 
 :::


### PR DESCRIPTION
What do you think?
I am afraid that some people may be unaware, that they can force macOS to open, and then normally use unauthorized apps.
Another solution (maybe with greater visibility) is to add README.txt to .dmg with that additional steps to do. 
![macOSdocs](https://github.com/vassbo/freeshow-net/assets/87763712/7f5fb06a-2244-44be-8c91-eafe08ab07c9)
