### PR TITLE
Add Keyboard Shortcuts as Own Page

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -93,6 +93,7 @@
                 Tips: [
                     // { title: "Roadmap", slug: "/docs/roadmap" },
                     { title: "Styling", slug: "/docs/styling" },
+                    { title: "Keyboard Shortcuts", slug: "/docs/shortcuts"}
                 ],
             },
         }

--- a/src/routes/docs/shortcuts/+page.md
+++ b/src/routes/docs/shortcuts/+page.md
@@ -1,0 +1,37 @@
+---
+title: Keyboard Shortcuts
+description: A list of shortcuts available in FreeShow.
+---
+
+# Keyboard Shortcuts
+
+*These commands can simplify and speed up common tasks in FreeShow.*
+
+
+|          Command          |  Shortcut  |
+|---------------------------|------------|
+| Change Tab                | NUM        |
+| Change Drawer Tab         | CTRL + NUM |
+| Select All                | CTRL + A   |
+| Copy                      | CTRL + C   |
+| Duplicate                 | CTRL + D   |
+| Export                    | CTRL + E   |
+| Toggle Fullscreen Preview | CTRL + F   |
+| Import                    | CTRL + I   |
+| Lock Output               | CTRL + L   |
+| Mute                      | CTRL + M   |
+| New Show                  | CTRL + N   |
+| Toggle Output Screen      | CTRL + O   |
+| Update Output             | CTRL + R   |
+| Save                      | CTRL + S   |
+| Paste                     | CTRL + V   |
+| Cut                       | CTRL + X   |
+| Redo                      | CTRL + Y   |
+| Undo                      | CTRL + Z   |
+| Clear All                 | ESC        |
+| Clear Background          | F1         |
+| Clear Slide               | F2         |
+| Clear Overlays            | F3         |
+| Clear Audio               | F4         |
+| Toggle Fullscreen         | F11        |
+


### PR DESCRIPTION
The online documentation should be as thorough as possible, and there shouldn't be anything about the app that a user would have to look up elsewhere. To that end, I thought it would be nice to include the keyboard shortcuts in the online documentation.

![image](https://github.com/vassbo/freeshow-net/assets/39384515/874e4e71-bce8-494b-a781-e6144c84ff53)
